### PR TITLE
refs platform/3177: upgrade agent to 17.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-07-30
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-gitlab-kubernetes-gitlab-agent/compare/0.5.0...0.6.0)
+
+### Added
+
+- Upgrade the default Helm chart to version `2.6.2`.
+
 ## [0.5.0] - 2024-07-30
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-gitlab-kubernetes-gitlab-agent/compare/0.4.0...0.5.0)

--- a/files/values.yaml.tftpl
+++ b/files/values.yaml.tftpl
@@ -1,4 +1,4 @@
-# https://gitlab.com/gitlab-org/charts/gitlab-agent/-/blob/v2.5.0/values.yaml
+# https://gitlab.com/gitlab-org/charts/gitlab-agent/-/blob/v2.6.2/values.yaml
 
 %{~ if length(k8s_common_labels) > 0 }
 additionalLabels:

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "helm_release_name" {
 variable "helm_chart_version" {
   description = "The version of the gitlab-agent Helm chart. You can see the available versions at https://gitlab.com/gitlab-org/charts/gitlab-agent/-/tags, or using the command `helm search repo gitlab/gitlab-agent -l` after adding the Gitlab Helm repository."
   type        = string
-  default     = "2.5.0"
+  default     = "2.6.2"
 }
 
 variable "helm_additional_values" {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded the GitLab Agent Helm chart version from 2.5.0 to 2.6.2
- This update aligns with the latest available version of the GitLab Agent Helm chart
- The change is made in the `variables.tf` file, updating the default value for the `helm_chart_version` variable
- This upgrade may include bug fixes, performance improvements, or new features for the GitLab Agent


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update GitLab Agent Helm Chart Version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<li>Updated the default value of <code>helm_chart_version</code> from "2.5.0" to <br>"2.6.2"<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-gitlab-kubernetes-gitlab-agent/pull/7/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

