### PR TITLE
fix: change changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-gitlab-kubernetes-gitlab-agent/compare/0.5.0...0.6.0)
 
-### Added
+### Changed
 
 - Upgrade the default Helm chart to version `2.6.2`.
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated the CHANGELOG.md file to correctly reflect the nature of changes in version 0.6.0.
- Changed the section header from "Added" to "Changed" for the upgrade of the default Helm chart to version 2.6.2.
- This modification ensures that the changelog accurately represents the type of changes made in the release.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog section header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Changed the section header from "Added" to "Changed" for the upgrade <br>of the default Helm chart to version 2.6.2.<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-gitlab-kubernetes-gitlab-agent/pull/8/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

