### PR TITLE
refs platform/4098:  upgrade agent default to 18.8.0

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "helm_release_name" {
 variable "helm_chart_version" {
   description = "The version of the gitlab-agent Helm chart. You can see the available versions at https://gitlab.com/gitlab-org/charts/gitlab-agent/-/tags, or using the command `helm search repo gitlab/gitlab-agent -l` after adding the Gitlab Helm repository."
   type        = string
-  default     = "2.20.1"
+  default     = "2.23.0"
 }
 
 variable "helm_additional_values" {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded GitLab agent Helm chart version from 2.20.1 to 2.23.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Helm Chart Version"] -- "upgrade" --> B["2.20.1 → 2.23.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Bump GitLab agent Helm chart version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<ul><li>Updated <code>helm_chart_version</code> default value from "2.20.1" to "2.23.0"</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-gitlab-kubernetes-gitlab-agent/pull/30/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

